### PR TITLE
fix(UI): Display correct round number

### DIFF
--- a/rock-paper-scissors.js
+++ b/rock-paper-scissors.js
@@ -155,9 +155,11 @@ class Round {
         const resultsDiv = document.querySelector(".results");
         resultsDiv.textContent = winMessage;
         const currStatus = document.createElement("div");
+        const nextRoundMessage = this.roundNum < 4 ? `Make a selection to play round ${this.roundNum + 2}!!`
+        : "This is the last round!!";
         currStatus.textContent = `You\'ve won ${currGame.playerWinCount} rounds. ` +
             `The computer has won ${this.roundNum - currGame.playerWinCount} rounds. ` +
-            `Make a selection to play round ${this.roundNum + 1}!!`
+            `${nextRoundMessage}`
         resultsDiv.appendChild(currStatus);
     }
 


### PR DESCRIPTION
Previously, the main header displayed the correct, current round number, but the round number in "Make a selection to play round ____" was incorrect. The round number displayed there was the same as the round number displayed in the main header, whereas it should be one more than the main header. This is because it represents the next round, not the current round. Correct this and include a special case message when the player is about to play the last round.